### PR TITLE
Release/0.2.0

### DIFF
--- a/PROCESS.md
+++ b/PROCESS.md
@@ -16,9 +16,9 @@
                                |
                                | object (T)
                                V
-                         /-----------\    evaluate(object, override?)
-                         | finalize  |  --------------------> [Attribute]
-                         \-----------/  <-------------------------/
+                         /-----------\   
+                         | finalize  | 
+                         \-----------/
                                |
                                | - onAfterBuild(object)
                                | - traits.each(it.onAfterBuild(object))
@@ -28,4 +28,10 @@
         object           /-----------\
   <-------------------   |  persist  |  
                          \-----------/
+                               |
+                               | object (T)
+                               V
+                         /-----------\    evaluate(object, override?)
+                         |  combine  |  --------------------> [Attribute]
+                         \-----------/  <-------------------------/
 ```

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -1,0 +1,31 @@
+# Building process
+
+```
+                         /-----------\    evaluate(override?)
+  build(overrides) --->  |   init    |  --------------------> [Attribute]
+                         \-----------/  <-------------------------/ 
+                               |   
+                               | - onAfterInit(attributes)
+                               | - traits.each(it.onAfterInit(attributes))
+                               |
+                               | attributes (Map<String, Object>)
+                               V
+                         /-----------\
+                         | construct |
+                         \-----------/
+                               |
+                               | object (T)
+                               V
+                         /-----------\    evaluate(object, override?)
+                         | finalize  |  --------------------> [Attribute]
+                         \-----------/  <-------------------------/
+                               |
+                               | - onAfterBuild(object)
+                               | - traits.each(it.onAfterBuild(object))
+                               |
+    build(object) ---------\   | object (T)
+                           V   V
+        object           /-----------\
+  <-------------------   |  persist  |  
+                         \-----------/
+```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Add the following to your dependencies:
     <dependency>
         <groupId>nl.topicus.overheid</groupId>
         <artifactId>java-factory-bot</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
         <scope>test</scope>
     </dependency>
 
@@ -86,7 +86,7 @@ Add the following to your dependencies:
 
 Add the following line to the dependency section of `build.gradle`
 
-    compile "nl.topicus.overheid:java-factory-bot:0.2.0-SNAPSHOT"
+    compile "nl.topicus.overheid:java-factory-bot:0.2.0"
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -37,19 +37,19 @@ we can define factories like
 ```groovy
 class ArticleFactory extends Factory<Article> {
     Map<String, Attribute> attributes = [
-            title       : attribute { faker.lorem().sentence() },
-            content     : attribute { faker.lorem().paragraph() },
-            creationDate: attribute { faker.date().past(20, TimeUnit.DAYS) },
+            title       : value { faker.lorem().sentence() },
+            content     : value { faker.lorem().paragraph() },
+            creationDate: value { faker.date().past(20, TimeUnit.DAYS) },
             author      : hasOne(UserFactory)
     ]
 }
 
 class UserFactory extends Factory<User> {
     Map<String, Attribute> attributes = [
-            username : attribute { faker.name().username() },
-            firstName: attribute { faker.name().firstName() },
-            lastName : attribute { faker.name().lastName() },
-            email    : attribute { "${get("firstName")}.${get("lastName")}@example.com" }
+            username : value { faker.name().username() },
+            firstName: value { faker.name().firstName() },
+            lastName : value { faker.name().lastName() },
+            email    : value { "${get("firstName")}.${get("lastName")}@example.com" }
     ]
 }
 ```
@@ -67,7 +67,7 @@ by passing them in a map:
 Article article = new ArticleFactory().build([title: "Foo", user: [username: "johndoe"]])
 ```
 
-For documentation, view the [wiki](https://github.com/topicusoverheid/java-factory-bot/wiki).
+For documentation and more examples, visit the [wiki](https://github.com/topicusoverheid/java-factory-bot/wiki).
 
 ## Installation
 
@@ -78,7 +78,7 @@ Add the following to your dependencies:
     <dependency>
         <groupId>nl.topicus.overheid</groupId>
         <artifactId>java-factory-bot</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <scope>test</scope>
     </dependency>
 
@@ -86,7 +86,7 @@ Add the following to your dependencies:
 
 Add the following line to the dependency section of `build.gradle`
 
-    compile "nl.topicus.overheid:java-factory-bot:0.1.0"
+    compile "nl.topicus.overheid:java-factory-bot:0.2.0-SNAPSHOT"
 
 ## Building
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compile.encoding>UTF-8</maven.compile.encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <gpg.keyname>3BFDF857</gpg.keyname>
 
         <!-- Dependency versions -->
         <gmavenplus-plugin.version>1.5</gmavenplus-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.topicus.overheid</groupId>
     <artifactId>java-factory-bot</artifactId>
-    <version>0.1.0</version>
+    <version>0.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>java-factory-bot</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.topicus.overheid</groupId>
     <artifactId>java-factory-bot</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.0</version>
     <packaging>jar</packaging>
 
     <name>java-factory-bot</name>

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/BaseFactory.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/BaseFactory.groovy
@@ -52,7 +52,7 @@ abstract class BaseFactory<M, F extends Faker> extends Definition<M> {
         if (object instanceof Map) {
             build(object as Map, [])
         } else {
-            persist(finalize(object, null), FactoryManager.instance.currentContext)
+            persist(object, FactoryManager.instance.currentContext)
         }
     }
 

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/BaseFactory.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/BaseFactory.groovy
@@ -1,12 +1,10 @@
 package nl.topicus.overheid.javafactorybot
 
 import com.github.javafaker.Faker
-import nl.topicus.overheid.javafactorybot.definition.Attribute
 import nl.topicus.overheid.javafactorybot.definition.Definition
 import nl.topicus.overheid.javafactorybot.exception.TraitNotFoundException
 
 import java.lang.reflect.ParameterizedType
-
 /**
  * A factory is a special class which is able to generate new valid objects, for testing purposes.
  * These objects can be randomized by using a faker.
@@ -40,18 +38,6 @@ abstract class BaseFactory<M, F extends Faker> extends Definition<M> {
     }
 
     /**
-     * Returns a map of attributes and relations based on the specified default attribute, default relations and build parameters.
-     *
-     * @param overrides The overrides specified to override default attributes and/or relations.
-     * @param traits A list of traits to apply.
-     * @return A map of attributes which can be used to create a new instance.
-     */
-    Map<String, Object> buildAttributes(Map<String, Object> overrides, List<String> traits = null) {
-        Evaluator evaluator = new Evaluator(this, compileAttributes(traits), overrides)
-        applyAfterAttributesHooks(evaluator.attributes())
-    }
-
-    /**
      * Returns the passed object.
      * <p>
      * This method exists so it is possible to completely override a relation by passing your own instance, or null.
@@ -65,7 +51,7 @@ abstract class BaseFactory<M, F extends Faker> extends Definition<M> {
         if (object instanceof Map) {
             build(object as Map, [])
         } else {
-            createIfInContext(applyAfterBuildHooks(object))
+            persist(object, FactoryManager.instance.currentContext)
         }
     }
 
@@ -73,7 +59,7 @@ abstract class BaseFactory<M, F extends Faker> extends Definition<M> {
      * Returns a new instance that is not saved.
      * <p>
      * In normal usage, this method should not be overriden. If you want to change how the object is built, use
-     * {@link #onAfterBuild} or {@link #internalBuild}.
+     * {@link #onAfterBuild} or {@link #construct}.
      *
      * @return The new instance.
      */
@@ -85,7 +71,7 @@ abstract class BaseFactory<M, F extends Faker> extends Definition<M> {
      * Returns a new instance that is not saved.
      * <p>
      * In normal usage, this method should not be overriden. If you want to change how the object is built, use
-     * {@link #onAfterBuild} or {@link #internalBuild}.
+     * {@link #onAfterBuild} or {@link #construct}.
      *
      * @param overrides Additional overrides to use when building a new object.
      * Build parameters allow to define custom values for attributes and relations.
@@ -94,15 +80,15 @@ abstract class BaseFactory<M, F extends Faker> extends Definition<M> {
      * @return The new instance.
      */
     M build(Map<String, Object> overrides, List<String> traits = null) {
-        M object = internalBuild(buildAttributes(overrides, traits))
-        createIfInContext(applyAfterBuildHooks(object, traits))
+        def evaluator = new Evaluator(this, traits, overrides)
+        persist(applyAfterBuildHooks(finalize(construct(init(evaluator)), evaluator), traits), FactoryManager.instance.currentContext)
     }
 
     /**
      * Returns a new instance that is not saved.
      * <p>
      * In normal usage, this method should not be overriden. If you want to change how the object is built, use
-     * {@link #onAfterBuild} or {@link #internalBuild}.
+     * {@link #onAfterBuild} or {@link #construct}.
      *
      * @param traits A list of traits to apply to new object. A trait is basically a collection of attribute/relation
      * updates, meant to create an object representing a certain state. The possible traits are specified in the factory.
@@ -116,7 +102,7 @@ abstract class BaseFactory<M, F extends Faker> extends Definition<M> {
      * Returns a new instance that is not saved.
      * <p>
      * In normal usage, this method should not be overriden. If you want to change how the object is built, use
-     * {@link #onAfterBuild} or {@link #internalBuild}.
+     * {@link #onAfterBuild} or {@link #construct}.
      *
      * @param traits An array of traits to apply to new object. A trait is basically a collection of attribute/relation
      * updates, meant to create an object representing a certain state. The possible traits are specified in the factory.
@@ -245,6 +231,12 @@ abstract class BaseFactory<M, F extends Faker> extends Definition<M> {
         doInCreateContext { buildList(overrides) }
     }
 
+    // Build process steps down here
+
+    protected Map<String, Object> init(Evaluator evaluator){
+        applyAfterAttributesHooks(evaluator.evaluateForBuildPhase(FactoryPhase.INIT))
+    }
+
     /**
      * Actual builder of the object, which creates the instance using the computed attributes.
      * This method is not used when {@link #build(M)} is called.
@@ -252,8 +244,12 @@ abstract class BaseFactory<M, F extends Faker> extends Definition<M> {
      * @param attributes The computed attributes of the object
      * @return A object with the values from the given attributes
      */
-    protected M internalBuild(Map attributes) {
+    protected M construct(Map attributes) {
         getObjectType().newInstance(attributes)
+    }
+
+    protected M finalize(M object, Evaluator evaluator) {
+        object
     }
 
     /**
@@ -264,35 +260,11 @@ abstract class BaseFactory<M, F extends Faker> extends Definition<M> {
      * @param context The context which should be used to persist the object.
      * @return The persisted object.
      */
-    protected M internalCreate(M object, FactoryContext context) {
-        if (object) context.persist(object) else object
+    protected M persist(M object, FactoryContext context = null) {
+        if (context != null) context.persist(object) else object
     }
 
     // Private methods down here
-
-    /**
-     * If create context is active, persist object. Otherwise, use unpersisted object.
-     */
-    private M createIfInContext(M object) {
-        def context = FactoryManager.instance.currentContext
-        context == null ? object : applyAfterCreateHooks(internalCreate(object, context))
-    }
-
-    /**
-     * Compile the list of traits into the base attributes
-     *
-     * @param traits List of traits to apply, can be null or empty.
-     * @return A map of attributes including attributes from the traits.
-     */
-    private Map<String, Attribute> compileAttributes(List<String> traits) {
-        if (traits != null && !traits.isEmpty()) {
-            traits.inject(attributes, { Map attributes, String traitName ->
-                attributes + findTrait(traitName).attributes
-            }) as Map<String, Attribute>
-        } else {
-            attributes
-        }
-    }
 
     /**
      * Find a trait by name, and throw an exception if a trait with that name does not exist.
@@ -318,15 +290,6 @@ abstract class BaseFactory<M, F extends Faker> extends Definition<M> {
     private M applyAfterBuildHooks(M object, List<String> traits = null) {
         onAfterBuild(object)
         if (traits) traits.each { findTrait(it).onAfterBuild(object) }
-        object
-    }
-
-    /**
-     * Apply all 'afterCreate' hooks from factory and possible traits.
-     */
-    private M applyAfterCreateHooks(M object, List<String> traits = null) {
-        onAfterCreate(object)
-        if (traits) traits.each { findTrait(it).onAfterCreate(object) }
         object
     }
 

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/BaseFactory.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/BaseFactory.groovy
@@ -10,8 +10,8 @@ import java.lang.reflect.ParameterizedType
  * A factory is a special class which is able to generate new valid objects, for testing purposes.
  * These objects can be randomized by using a faker.
  *
- * @param < M >            The type of the generated object
- * @param < F >            The type of the faker of this factory. This allows to override the faker with a custom implementation.
+ * @param < M >             The type of the generated object
+ * @param < F >             The type of the faker of this factory. This allows to override the faker with a custom implementation.
  */
 abstract class BaseFactory<M, F extends Faker> extends Definition<M> {
     /**
@@ -264,7 +264,7 @@ abstract class BaseFactory<M, F extends Faker> extends Definition<M> {
      * @return The persisted object.
      */
     protected M persist(M object, FactoryContext context = null) {
-        if (context != null) context.persist(object) else object
+        if (context != null && object != null) context.persist(object) else object
     }
 
     // Private methods down here

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/Evaluator.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/Evaluator.groovy
@@ -21,12 +21,12 @@ class Evaluator {
     }
 
     Map<String, Object> evaluatorForInitPhase() {
-        Map<String, Attribute> activeAttributes = attributes.findAll { it.value.activePhase == FactoryPhase.INIT }
+        Map<String, Attribute> activeAttributes = attributes.findAll { !it.value.afterBuild }
         evaluateForKeys(overrides ? overrides.keySet() + activeAttributes.keySet() : activeAttributes.keySet())
     }
 
     Map<String, Object> evaluatorForFinalizePhase(Object owner) {
-        Map<String, Attribute> activeAttributes = attributes.findAll { it.value.activePhase == FactoryPhase.FINALIZE }
+        Map<String, Attribute> activeAttributes = attributes.findAll { it.value.afterBuild }
         evaluateForKeys(activeAttributes.keySet(), owner)
     }
 

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/FactoryPhase.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/FactoryPhase.groovy
@@ -1,0 +1,5 @@
+package nl.topicus.overheid.javafactorybot
+
+enum FactoryPhase {
+    INIT, FINALIZE
+}

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/FactoryPhase.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/FactoryPhase.groovy
@@ -1,5 +1,0 @@
-package nl.topicus.overheid.javafactorybot
-
-enum FactoryPhase {
-    INIT, FINALIZE
-}

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/AbstractFactoryAttribute.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/AbstractFactoryAttribute.groovy
@@ -1,0 +1,51 @@
+package nl.topicus.overheid.javafactorybot.definition
+
+import com.github.javafaker.Faker
+import nl.topicus.overheid.javafactorybot.BaseFactory
+import nl.topicus.overheid.javafactorybot.FactoryManager
+
+/**
+ * Abstract class for attributes which are based on using another factory.
+ */
+abstract class AbstractFactoryAttribute<T> {
+    private Class<? extends BaseFactory<T, ? extends Faker>> factoryClass
+    private BaseFactory<T, ? extends Faker> factory
+
+    /**
+     * Create a new instance.
+     *
+     * @param factory The factory to use for the associated object.
+     */
+    AbstractFactoryAttribute(BaseFactory<T, ? extends Faker> factory) {
+        this.factory = factory
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param factoryClass The class of the factory to use for the associated object.
+     *  The factory itself is lazily initialized using {@link FactoryManager#getFactoryInstance(java.lang.Class)}
+     */
+    AbstractFactoryAttribute(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass) {
+        this.factoryClass = factoryClass
+    }
+
+    /**
+     * Returns an instance of the factory.
+     * This is either the specified instance, or a new instance which is created using {@link FactoryManager#getFactoryInstance(java.lang.Class)}.
+     *
+     * @return An instance of the factory.
+     */
+    BaseFactory getFactory() {
+        if (factory == null) {
+            if (factoryClass != null) {
+                factory = FactoryManager.instance.getFactoryInstance(factoryClass)
+            } else {
+                throw new IllegalArgumentException("Association defined without factory of factoryclass")
+            }
+        }
+        factory
+    }
+}
+
+

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Association.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Association.groovy
@@ -12,8 +12,7 @@ import nl.topicus.overheid.javafactorybot.BaseFactory
 class Association<T> implements Attribute {
     private BaseFactory factory
     private Map<String, Object> defaultOverrides
-    private boolean withDefaultObject = false
-    private T defaultObject
+    private Closure<T> defaultObjectProducer
     private List<String> traits
 
     /**
@@ -31,11 +30,10 @@ class Association<T> implements Attribute {
     /**
      * Create a new Association which uses user specified overrides or, in absence of these, uses the given object.
      * @param factory The factory to use for the associated object.
-     * @param defaultObject The default object to be used when no overrides are given.
+     * @param defaultObjectProducer A closure which yields the default object which should be used when no overrides are given.
      */
-    Association(BaseFactory<T, ? extends Faker> factory, T defaultObject) {
-        this.withDefaultObject = true
-        this.defaultObject = defaultObject
+    Association(BaseFactory<T, ? extends Faker> factory, Closure<T> defaultObjectProducer) {
+        this.defaultObjectProducer = defaultObjectProducer
         this.factory = factory
     }
 
@@ -44,9 +42,9 @@ class Association<T> implements Attribute {
         if (defaultOverrides != null) {
             // Build using the default overrides
             factory.build(defaultOverrides, traits)
-        } else if (withDefaultObject) {
+        } else if (defaultObjectProducer != null) {
             // Build using the default object
-            factory.build(defaultObject)
+            factory.build(defaultObjectProducer())
         } else {
             // Default build
             factory.build()

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Association.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Association.groovy
@@ -4,8 +4,6 @@ import com.github.javafaker.Faker
 import nl.topicus.overheid.javafactorybot.BaseFactory
 import nl.topicus.overheid.javafactorybot.Evaluator
 import nl.topicus.overheid.javafactorybot.FactoryManager
-import nl.topicus.overheid.javafactorybot.FactoryPhase
-
 /**
  * Attribute used to define an association with another object, using a factory. A combination of the default overrides,
  * default object, traits and user specified overrides is used to create the associated object using the factory.
@@ -15,7 +13,7 @@ class Association<T> extends AbstractFactoryAttribute<T> implements Attribute{
     Closure<Map<String, Object>> defaultOverridesProducer
     Closure<T> defaultObjectProducer
     List<String> traits
-    FactoryPhase activePhase = FactoryPhase.INIT
+    boolean afterBuild = false
 
     /**
      * Create a new Association which combines user specified overrides with optional default overrides and traits.

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Association.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Association.groovy
@@ -46,7 +46,7 @@ class Association<T> extends AbstractFactoryAttribute<T> implements Attribute{
             getFactory().build(defaultObjectProducer())
         } else {
             // Default build
-            getFactory().build()
+            traits ? getFactory().build(traits) : getFactory().build()
         }
     }
 

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Association.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Association.groovy
@@ -4,6 +4,7 @@ import com.github.javafaker.Faker
 import nl.topicus.overheid.javafactorybot.BaseFactory
 import nl.topicus.overheid.javafactorybot.Evaluator
 import nl.topicus.overheid.javafactorybot.FactoryManager
+import nl.topicus.overheid.javafactorybot.FactoryPhase
 
 /**
  * Attribute used to define an association with another object, using a factory. A combination of the default overrides,
@@ -11,9 +12,11 @@ import nl.topicus.overheid.javafactorybot.FactoryManager
  * @param < T >    The type of the associated object.
  */
 class Association<T> extends AbstractFactoryAttribute<T> implements Attribute{
-    private Map<String, Object> defaultOverrides
-    private Closure<T> defaultObjectProducer
-    private List<String> traits
+    Map<String, Object> defaultOverrides
+    Closure<T> defaultObjectProducer
+    List<String> traits
+    String inverse
+    FactoryPhase activePhase = FactoryPhase.INIT
 
     /**
      * Create a new Association which combines user specified overrides with optional default overrides and traits.

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Association.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Association.groovy
@@ -15,7 +15,6 @@ class Association<T> extends AbstractFactoryAttribute<T> implements Attribute{
     Closure<Map<String, Object>> defaultOverridesProducer
     Closure<T> defaultObjectProducer
     List<String> traits
-    String inverse
     FactoryPhase activePhase = FactoryPhase.INIT
 
     /**
@@ -24,20 +23,8 @@ class Association<T> extends AbstractFactoryAttribute<T> implements Attribute{
      * @param defaultOverrides Default overrides to pass to the factory. Can be overriden by user specified overrides.
      * @param traits List of traits to apply to the associated object.
      */
-    Association(BaseFactory<T, ? extends Faker> factory, Map<String, Object> defaultOverrides = null, List<String> traits = null) {
+    Association(BaseFactory<T, ? extends Faker> factory) {
         super(factory)
-        this.defaultOverridesProducer = { defaultOverrides }
-        this.traits = traits
-    }
-
-    /**
-     * Create a new Association which uses user specified overrides or, in absence of these, uses the given object.
-     * @param factory The factory to use for the associated object.
-     * @param defaultObjectProducer A closure which yields the default object which should be used when no overrides are given.
-     */
-    Association(BaseFactory<T, ? extends Faker> factory, Closure<T> defaultObjectProducer) {
-        super(factory)
-        this.defaultObjectProducer = defaultObjectProducer
     }
 
     /**
@@ -47,21 +34,8 @@ class Association<T> extends AbstractFactoryAttribute<T> implements Attribute{
      * @param defaultOverrides Default overrides to pass to the factory. Can be overriden by user specified overrides.
      * @param traits List of traits to apply to the associated object.
      */
-    Association(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, Map<String, Object> defaultOverrides = null, List<String> traits = null) {
+    Association(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass) {
         super(factoryClass)
-        this.defaultOverridesProducer = { defaultOverrides }
-        this.traits = traits
-    }
-
-    /**
-     * Create a new Association which uses user specified overrides or, in absence of these, uses the given object.
-     * @param factoryClass The class of the factory to use for the associated object.
-     * The factory itself is lazily initialized using {@link FactoryManager#getFactoryInstance(java.lang.Class)}.
-     * @param defaultObjectProducer A closure which yields the default object which should be used when no overrides are given.
-     */
-    Association(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, Closure<T> defaultObjectProducer) {
-        super(factoryClass)
-        this.defaultObjectProducer = defaultObjectProducer
     }
 
     @Override

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Association.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Association.groovy
@@ -1,16 +1,16 @@
 package nl.topicus.overheid.javafactorybot.definition
 
 import com.github.javafaker.Faker
-import nl.topicus.overheid.javafactorybot.Evaluator
 import nl.topicus.overheid.javafactorybot.BaseFactory
+import nl.topicus.overheid.javafactorybot.Evaluator
+import nl.topicus.overheid.javafactorybot.FactoryManager
 
 /**
  * Attribute used to define an association with another object, using a factory. A combination of the default overrides,
  * default object, traits and user specified overrides is used to create the associated object using the factory.
- * @param < T > The type of the associated object.
+ * @param < T >    The type of the associated object.
  */
-class Association<T> implements Attribute {
-    private BaseFactory factory
+class Association<T> extends AbstractFactoryAttribute<T> implements Attribute{
     private Map<String, Object> defaultOverrides
     private Closure<T> defaultObjectProducer
     private List<String> traits
@@ -22,9 +22,9 @@ class Association<T> implements Attribute {
      * @param traits List of traits to apply to the associated object.
      */
     Association(BaseFactory<T, ? extends Faker> factory, Map<String, Object> defaultOverrides = null, List<String> traits = null) {
+        super(factory)
         this.defaultOverrides = defaultOverrides
         this.traits = traits
-        this.factory = factory
     }
 
     /**
@@ -33,31 +33,55 @@ class Association<T> implements Attribute {
      * @param defaultObjectProducer A closure which yields the default object which should be used when no overrides are given.
      */
     Association(BaseFactory<T, ? extends Faker> factory, Closure<T> defaultObjectProducer) {
+        super(factory)
         this.defaultObjectProducer = defaultObjectProducer
-        this.factory = factory
+    }
+
+    /**
+     * Create a new Association which combines user specified overrides with optional default overrides and traits.
+     * @param factoryClass The class of the factory to use for the associated object.
+     * The factory itself is lazily initialized using {@link FactoryManager#getFactoryInstance(java.lang.Class)}
+     * @param defaultOverrides Default overrides to pass to the factory. Can be overriden by user specified overrides.
+     * @param traits List of traits to apply to the associated object.
+     */
+    Association(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, Map<String, Object> defaultOverrides = null, List<String> traits = null) {
+        super(factoryClass)
+        this.defaultOverrides = defaultOverrides
+        this.traits = traits
+    }
+
+    /**
+     * Create a new Association which uses user specified overrides or, in absence of these, uses the given object.
+     * @param factoryClass The class of the factory to use for the associated object.
+     * The factory itself is lazily initialized using {@link FactoryManager#getFactoryInstance(java.lang.Class)}.
+     * @param defaultObjectProducer A closure which yields the default object which should be used when no overrides are given.
+     */
+    Association(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, Closure<T> defaultObjectProducer) {
+        super(factoryClass)
+        this.defaultObjectProducer = defaultObjectProducer
     }
 
     @Override
     def evaluate(Evaluator evaluator) {
         if (defaultOverrides != null) {
             // Build using the default overrides
-            factory.build(defaultOverrides, traits)
+            getFactory().build(defaultOverrides, traits)
         } else if (defaultObjectProducer != null) {
             // Build using the default object
-            factory.build(defaultObjectProducer())
+            getFactory().build(defaultObjectProducer())
         } else {
             // Default build
-            factory.build()
+            getFactory().build()
         }
     }
 
     @Override
     def evaluate(Object override, Evaluator evaluator) {
         if (override == null || override instanceof T) {
-            factory.build((T) override)
+            getFactory().build((T) override)
         } else if (override instanceof Map) {
             // override given as map, use these together with default overrides to build the object
-            factory.build(defaultOverrides ? defaultOverrides + override : override, traits)
+            getFactory().build(defaultOverrides ? defaultOverrides + override : override, traits)
         } else {
             throw new IllegalArgumentException("Override should be null, a Map or an object of the associated type")
         }

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Attribute.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Attribute.groovy
@@ -1,7 +1,6 @@
 package nl.topicus.overheid.javafactorybot.definition
 
 import nl.topicus.overheid.javafactorybot.Evaluator
-import nl.topicus.overheid.javafactorybot.FactoryPhase
 
 /**
  * Interface of a definition of an attribute of an object. An Attribute is responsible for generating the value of the
@@ -30,5 +29,12 @@ interface Attribute extends GroovyObject {
      */
     def evaluate(Object override, Evaluator evaluator, Object owner)
 
-    FactoryPhase getActivePhase()
+    /**
+     * Determines if this attribute should be evaluated before or after the owner object is build.
+     *
+     * If the result is {@code false}, the attribute will be evaluated during the init phase (in which attributes are build).
+     * If the result is {@code true}, the attribute will be evaluated during the finalize phase (after build, before optional persist).
+     * @return If the attribute should be evaluated after the owner object is build.
+     */
+    boolean isAfterBuild()
 }

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Attribute.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Attribute.groovy
@@ -32,8 +32,8 @@ interface Attribute extends GroovyObject {
     /**
      * Determines if this attribute should be evaluated before or after the owner object is build.
      *
-     * If the result is {@code false}, the attribute will be evaluated during the init phase (in which attributes are build).
-     * If the result is {@code true}, the attribute will be evaluated during the finalize phase (after build, before optional persist).
+     * If the result is {@code false}, the attribute will be evaluated during the initialize build step (in which attributes are build).
+     * If the result is {@code true}, the attribute will be evaluated during the combine build step (after persist).
      * @return If the attribute should be evaluated after the owner object is build.
      */
     boolean isAfterBuild()

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Attribute.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Attribute.groovy
@@ -1,6 +1,7 @@
 package nl.topicus.overheid.javafactorybot.definition
 
 import nl.topicus.overheid.javafactorybot.Evaluator
+import nl.topicus.overheid.javafactorybot.FactoryPhase
 
 /**
  * Interface of a definition of an attribute of an object. An Attribute is responsible for generating the value of the
@@ -26,4 +27,6 @@ interface Attribute extends GroovyObject {
      * @return The value of this attribute.
      */
     def evaluate(Object override, Evaluator evaluator)
+
+    FactoryPhase getActivePhase()
 }

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Attribute.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Attribute.groovy
@@ -13,20 +13,22 @@ interface Attribute extends GroovyObject {
      * Get the value of this attribute, possibly using the given evaluator.
      *
      * @param evaluator The evaluator which can be used to determine the value of other attribute.
+     * @param owner The owner of the value of the attribute, if the owner is already build.
      * @return The value of this attribute.
      */
-    def evaluate(Evaluator evaluator)
+    def evaluate(Evaluator evaluator, Object owner)
 
     /**
      * Get the value of this attribute using the given override, possibly using the given evaluator.
      *
      * @param override The override for this attribute, as given by the user. This can be intentionally null, for
-     * instance when the value of the attribute should be null. If no override is given {@link #evaluate(Evaluator)}
+     * instance when the value of the attribute should be null. If no override is given {@link #evaluate(Evaluator, Object)}
      * is used instead.
      * @param evaluator The evaluator which can be used to determine the value of other attribute.
+     * @param owner The owner of the value of the attribute, if the owner is already build.
      * @return The value of this attribute.
      */
-    def evaluate(Object override, Evaluator evaluator)
+    def evaluate(Object override, Evaluator evaluator, Object owner)
 
     FactoryPhase getActivePhase()
 }

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Definition.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/Definition.groovy
@@ -1,12 +1,13 @@
 package nl.topicus.overheid.javafactorybot.definition
 
-import nl.topicus.overheid.javafactorybot.factory.FactoryHooks
 import nl.topicus.overheid.javafactorybot.factory.FactoryAttributes
+import nl.topicus.overheid.javafactorybot.factory.FactoryDSL
+import nl.topicus.overheid.javafactorybot.factory.FactoryHooks
 import nl.topicus.overheid.javafactorybot.factory.FactoryTraits
 
 /**
  * A definition is the base class containing the definition of how an object should be created. This base is used by
  * both the factory and traits, to allow to use the same syntax for both.
  */
-class Definition<M> implements FactoryHooks<M>, FactoryAttributes, FactoryTraits<M> {
+class Definition<M> implements FactoryHooks<M>, FactoryAttributes, FactoryDSL, FactoryTraits<M> {
 }

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/ManyAssociation.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/ManyAssociation.groovy
@@ -3,6 +3,7 @@ package nl.topicus.overheid.javafactorybot.definition
 import com.github.javafaker.Faker
 import nl.topicus.overheid.javafactorybot.BaseFactory
 import nl.topicus.overheid.javafactorybot.Evaluator
+import nl.topicus.overheid.javafactorybot.FactoryPhase
 
 /**
  * Attribute used to define an association with a list of objects, using a factory.
@@ -15,6 +16,8 @@ class ManyAssociation<T> extends AbstractFactoryAttribute<T> implements Attribut
     private List<Object> defaultOverrides
     private int amount
     private List<String> traits
+
+    FactoryPhase activePhase = FactoryPhase.INIT
 
     /**
      * Create a new Association which combines user specified overrides with optional default overrides and traits.

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/ManyAssociation.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/ManyAssociation.groovy
@@ -1,17 +1,16 @@
 package nl.topicus.overheid.javafactorybot.definition
 
 import com.github.javafaker.Faker
-import nl.topicus.overheid.javafactorybot.Evaluator
 import nl.topicus.overheid.javafactorybot.BaseFactory
+import nl.topicus.overheid.javafactorybot.Evaluator
 
 /**
  * Attribute used to define an association with a list of objects, using a factory.
  * A combination of the default overrides, default object, traits and user specified overrides is used to create the
  * associated object using the factory.
- * @param < T > The type of the associated object.
+ * @param < T >  The type of the associated object.
  */
-class ManyAssociation<T> implements Attribute {
-    private BaseFactory factory
+class ManyAssociation<T> extends AbstractFactoryAttribute<T> implements Attribute {
     private Map<String, Object> defaultItemOverrides
     private List<Object> defaultOverrides
     private int amount
@@ -24,7 +23,7 @@ class ManyAssociation<T> implements Attribute {
      * @param traits List of traits to apply to the associated object.
      */
     ManyAssociation(BaseFactory<T, ? extends Faker> factory, int amount, Map<String, Object> defaultItemOverrides = null, List<String> traits = null) {
-        this.factory = factory
+        super(factory)
         this.amount = amount
         this.defaultItemOverrides = defaultItemOverrides
         this.traits = traits
@@ -37,7 +36,35 @@ class ManyAssociation<T> implements Attribute {
      * @param traits List of traits to apply to the associated object.
      */
     ManyAssociation(BaseFactory<T, ? extends Faker> factory, List<Object> defaultOverrides, List<String> traits = null) {
-        this.factory = factory
+        super(factory)
+        this.amount = defaultOverrides.size()
+        this.defaultOverrides = defaultOverrides
+        this.traits = traits
+    }
+
+    /**
+     * Create a new Association which combines user specified overrides with optional default overrides and traits.
+     * @param factoryClass The class of the factory to use for the associated object.
+     * The factory itself is lazily initialized using {@link nl.topicus.overheid.javafactorybot.FactoryManager#getFactoryInstance(java.lang.Class)}.
+     * @param defaultOverrides Default overrides to pass to the factory. Can be overriden by user specified overrides.
+     * @param traits List of traits to apply to the associated object.
+     */
+    ManyAssociation(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, int amount, Map<String, Object> defaultItemOverrides = null, List<String> traits = null) {
+        super(factoryClass)
+        this.amount = amount
+        this.defaultItemOverrides = defaultItemOverrides
+        this.traits = traits
+    }
+
+    /**
+     * Create a new Association which combines user specified overrides with optional default overrides and traits.
+     * @param factoryClass The class of the factory to use for the associated object.
+     * The factory itself is lazily initialized using {@link nl.topicus.overheid.javafactorybot.FactoryManager#getFactoryInstance(java.lang.Class)}.
+     * @param defaultOverrides Default overrides to pass to the factory. Can be overriden by user specified overrides.
+     * @param traits List of traits to apply to the associated object.
+     */
+    ManyAssociation(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, List<Object> defaultOverrides, List<String> traits = null) {
+        super(factoryClass)
         this.amount = defaultOverrides.size()
         this.defaultOverrides = defaultOverrides
         this.traits = traits
@@ -46,21 +73,21 @@ class ManyAssociation<T> implements Attribute {
     @Override
     def evaluate(Evaluator evaluator) {
         if (defaultOverrides != null) {
-            factory.buildList(defaultOverrides)
+            getFactory().buildList(defaultOverrides)
         } else if (defaultItemOverrides != null) {
-            factory.buildList(amount, defaultItemOverrides)
+            getFactory().buildList(amount, defaultItemOverrides)
         } else {
-            factory.buildList(amount)
+            getFactory().buildList(amount)
         }
     }
 
     @Override
     def evaluate(Object override, Evaluator evaluator) {
         if (override instanceof List) {
-            factory.buildList(compileListOverride(override))
+            getFactory().buildList(compileListOverride(override))
         } else if (override instanceof Integer) {
             // Build the given amount of object
-            factory.buildList(override)
+            getFactory().buildList(override)
         } else {
             throw new IllegalArgumentException("Override for a toMany association should be an integer (amount) " +
                     "or a list containing individual overrides/objects. " +
@@ -71,7 +98,7 @@ class ManyAssociation<T> implements Attribute {
     List<Object> compileListOverride(List override) {
         // A list is given. Each element in the list should be either a map with overrides, or an object (or null)
         // If it is a map, we merge it with the default overrides, just as we do with single associations
-        override.collect{it instanceof Map && defaultItemOverrides ? defaultItemOverrides + it : it}
+        override.collect { it instanceof Map && defaultItemOverrides ? defaultItemOverrides + it : it }
     }
 
 }

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/ManyAssociation.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/ManyAssociation.groovy
@@ -3,8 +3,6 @@ package nl.topicus.overheid.javafactorybot.definition
 import com.github.javafaker.Faker
 import nl.topicus.overheid.javafactorybot.BaseFactory
 import nl.topicus.overheid.javafactorybot.Evaluator
-import nl.topicus.overheid.javafactorybot.FactoryPhase
-
 /**
  * Attribute used to define an association with a list of objects, using a factory.
  * A combination of the default overrides, default object, traits and user specified overrides is used to create the
@@ -16,8 +14,7 @@ class ManyAssociation<T> extends AbstractFactoryAttribute<T> implements Attribut
     List<T> overrides
     int amount
     List<String> traits
-
-    FactoryPhase activePhase = FactoryPhase.INIT
+    boolean afterBuild = false
 
     /**
      * Create a new Association which combines user specified overrides with optional default overrides and traits.

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/ManyAssociation.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/ManyAssociation.groovy
@@ -74,7 +74,7 @@ class ManyAssociation<T> extends AbstractFactoryAttribute<T> implements Attribut
     }
 
     @Override
-    def evaluate(Evaluator evaluator) {
+    def evaluate(Evaluator evaluator, Object owner) {
         if (defaultOverrides != null) {
             getFactory().buildList(defaultOverrides)
         } else if (defaultItemOverrides != null) {
@@ -85,7 +85,7 @@ class ManyAssociation<T> extends AbstractFactoryAttribute<T> implements Attribut
     }
 
     @Override
-    def evaluate(Object override, Evaluator evaluator) {
+    def evaluate(Object override, Evaluator evaluator, Object owner) {
         if (override instanceof List) {
             getFactory().buildList(compileListOverride(override))
         } else if (override instanceof Integer) {

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/ValueAttribute.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/ValueAttribute.groovy
@@ -1,8 +1,10 @@
 package nl.topicus.overheid.javafactorybot.definition
 
+
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import nl.topicus.overheid.javafactorybot.Evaluator
+import nl.topicus.overheid.javafactorybot.FactoryPhase
 
 /**
  * Attribute which has a single value. The value is either the user specified override, or the result of the given
@@ -10,6 +12,7 @@ import nl.topicus.overheid.javafactorybot.Evaluator
  */
 class ValueAttribute implements Attribute {
     private Closure defaultValueGenerator
+    FactoryPhase activePhase
 
     /**
      * Create a new ValueAttribute which yields the result of the given closure when no override is specified, or the
@@ -17,8 +20,9 @@ class ValueAttribute implements Attribute {
      * @param defaultValueGenerator The closure of which the result is yielded when no override is speicified.
      */
     ValueAttribute(
-            @DelegatesTo(Evaluator) @ClosureParams(value = SimpleType, options = "Evaluator") Closure defaultValueGenerator) {
+            @DelegatesTo(Evaluator) @ClosureParams(value = SimpleType, options = "Evaluator") Closure defaultValueGenerator, activePhase = FactoryPhase.INIT) {
         this.defaultValueGenerator = defaultValueGenerator
+        this.activePhase = activePhase
     }
 
     @Override

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/ValueAttribute.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/ValueAttribute.groovy
@@ -1,18 +1,15 @@
 package nl.topicus.overheid.javafactorybot.definition
 
-
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import nl.topicus.overheid.javafactorybot.Evaluator
-import nl.topicus.overheid.javafactorybot.FactoryPhase
-
 /**
  * Attribute which has a single value. The value is either the user specified override, or the result of the given
  * value generator closure.
  */
 class ValueAttribute implements Attribute {
     private Closure defaultValueGenerator
-    FactoryPhase activePhase
+    boolean afterBuild = false
 
     /**
      * Create a new ValueAttribute which yields the result of the given closure when no override is specified, or the
@@ -20,9 +17,9 @@ class ValueAttribute implements Attribute {
      * @param defaultValueGenerator The closure of which the result is yielded when no override is speicified.
      */
     ValueAttribute(
-            @DelegatesTo(Evaluator) @ClosureParams(value = SimpleType, options = "Evaluator") Closure defaultValueGenerator, activePhase = FactoryPhase.INIT) {
+            @DelegatesTo(Evaluator) @ClosureParams(value = SimpleType, options = "Evaluator") Closure defaultValueGenerator, boolean afterBuild = false) {
         this.defaultValueGenerator = defaultValueGenerator
-        this.activePhase = activePhase
+        this.afterBuild = afterBuild
     }
 
     @Override

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/ValueAttribute.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/definition/ValueAttribute.groovy
@@ -26,13 +26,13 @@ class ValueAttribute implements Attribute {
     }
 
     @Override
-    def evaluate(Evaluator evaluator) {
+    def evaluate(Evaluator evaluator, Object owner) {
         defaultValueGenerator.delegate = evaluator
         defaultValueGenerator(evaluator)
     }
 
     @Override
-    def evaluate(Object override, Evaluator evaluator) {
+    def evaluate(Object override, Evaluator evaluator, Object owner) {
         override
     }
 }

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryAttributes.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryAttributes.groovy
@@ -1,100 +1,15 @@
 package nl.topicus.overheid.javafactorybot.factory
 
-import com.github.javafaker.Faker
-import groovy.transform.stc.ClosureParams
-import groovy.transform.stc.SimpleType
-import nl.topicus.overheid.javafactorybot.BaseFactory
-import nl.topicus.overheid.javafactorybot.Evaluator
-import nl.topicus.overheid.javafactorybot.definition.Association
+
 import nl.topicus.overheid.javafactorybot.definition.Attribute
-import nl.topicus.overheid.javafactorybot.definition.ManyAssociation
-import nl.topicus.overheid.javafactorybot.definition.ValueAttribute
 
 trait FactoryAttributes {
     /**
-     * Map containing {@link nl.topicus.overheid.javafactorybot.definition.Attribute}s of this factory. An {@link nl.topicus.overheid.javafactorybot.definition.Attribute} is a definition of an attribute in the
+     * Map containing {@link Attribute}s of this factory. An {@link Attribute} is a definition of an attribute in the
      * (generated) object, and minimally implements a function which, given an instance of {@link nl.topicus.overheid.javafactorybot.Evaluator}, yields the
      * value this attribute should have in the generated object.
      *
-     * @return A map containing the {@link nl.topicus.overheid.javafactorybot.definition.Attribute}s of this factory.
+     * @return A map containing the {@link Attribute}s of this factory.
      */
     Map<String, Attribute> attributes = [:]
-
-    /**
-     * Creates a new attribute which either uses the user specified override or the result of the closure.
-     *
-     * @param defaultValueGenerator The closure which generates a value when no override is given.
-     * @return An attribute which resolves to the override or the result of the closure.
-     */
-    ValueAttribute value(@DelegatesTo(Evaluator) @ClosureParams(value = SimpleType, options = "Evaluator") Closure defaultValueGenerator) {
-        new ValueAttribute(defaultValueGenerator)
-    }
-
-    def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass) {
-        new Association<>(factoryClass)
-    }
-
-    def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory) {
-        new Association<>(factory)
-    }
-
-    def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, Closure<T> defaultObjectProducer) {
-        new Association<>(factoryClass, defaultObjectProducer)
-    }
-
-    def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory, Closure<T> defaultObjectProducer) {
-        new Association<>(factory, defaultObjectProducer)
-    }
-
-    def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, Map<String, ? extends Object> overrides, List<String> traits = null) {
-        new Association<>(factoryClass, overrides, traits)
-    }
-
-    def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory, Map<String, ? extends Object> overrides, List<String> traits = null) {
-        new Association<>(factory, overrides, traits)
-    }
-
-    def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, List<String> traits) {
-        hasOne(factoryClass, [:], traits)
-    }
-
-    def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory, List<String> traits) {
-        hasOne(factory, [:], traits)
-    }
-
-    // Special version for groovy syntax
-    def <T> Association<T> hasOne(Map<String, ? extends Object> overrides, Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, List<String> traits = null) {
-        hasOne(factoryClass, overrides, traits)
-    }
-
-    // Special version for groovy syntax
-    def <T> Association<T> hasOne(Map<String, ? extends Object> overrides, BaseFactory<T, ? extends Faker> factory, List<String> traits = null) {
-        hasOne(factory, overrides, traits)
-    }
-
-    def <T> ManyAssociation<T> hasMany(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, int amount = 0, Map<String, ? extends Object> overrides = null, List<String> traits = null) {
-        new ManyAssociation<>(factoryClass, amount, overrides, traits)
-    }
-
-    def <T> ManyAssociation<T> hasMany(BaseFactory<T, ? extends Faker> factory, int amount = 0, Map<String, ? extends Object> overrides = null, List<String> traits = null) {
-        new ManyAssociation<>(factory, amount, overrides, traits)
-    }
-
-    // Special version for groovy syntax
-    def <T> ManyAssociation<T> hasMany(Map<String, ? extends Object> overrides, Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, int amount = 0, List<String> traits = null) {
-        hasMany(factoryClass, amount, overrides, traits)
-    }
-
-    // Special version for groovy syntax
-    def <T> ManyAssociation<T> hasMany(Map<String, ? extends Object> overrides, BaseFactory<T, ? extends Faker> factory, int amount = 0, List<String> traits = null) {
-        hasMany(factory, amount, overrides, traits)
-    }
-
-    def <T> ManyAssociation<T> hasMany(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, List<Object> defaultOverrides, List<String> traits = null) {
-        new ManyAssociation<>(factoryClass, defaultOverrides, traits)
-    }
-
-    def <T> ManyAssociation<T> hasMany(BaseFactory<T, ? extends Faker> factory, List<Object> defaultOverrides, List<String> traits = null) {
-        new ManyAssociation<>(factory, defaultOverrides, traits)
-    }
 }

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryAttributes.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryAttributes.groovy
@@ -27,7 +27,7 @@ trait FactoryAttributes {
      * @param defaultValueGenerator The closure which generates a value when no override is given.
      * @return An attribute which resolves to the override or the result of the closure.
      */
-    ValueAttribute attribute(@DelegatesTo(Evaluator) @ClosureParams(value = SimpleType, options = "Evaluator") Closure defaultValueGenerator) {
+    ValueAttribute value(@DelegatesTo(Evaluator) @ClosureParams(value = SimpleType, options = "Evaluator") Closure defaultValueGenerator) {
         new ValueAttribute(defaultValueGenerator)
     }
 

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryAttributes.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryAttributes.groovy
@@ -5,7 +5,6 @@ import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import nl.topicus.overheid.javafactorybot.BaseFactory
 import nl.topicus.overheid.javafactorybot.Evaluator
-import nl.topicus.overheid.javafactorybot.FactoryManager
 import nl.topicus.overheid.javafactorybot.definition.Association
 import nl.topicus.overheid.javafactorybot.definition.Attribute
 import nl.topicus.overheid.javafactorybot.definition.ManyAssociation
@@ -32,7 +31,7 @@ trait FactoryAttributes {
     }
 
     def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass) {
-        hasOne(FactoryManager.instance.getFactoryInstance(factoryClass))
+        new Association<>(factoryClass)
     }
 
     def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory) {
@@ -40,19 +39,23 @@ trait FactoryAttributes {
     }
 
     def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, Closure<T> defaultObjectProducer) {
-        hasOne(FactoryManager.instance.getFactoryInstance(factoryClass), defaultObjectProducer)
+        new Association<>(factoryClass, defaultObjectProducer)
     }
 
-    def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory,  Closure<T> defaultObjectProducer) {
+    def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory, Closure<T> defaultObjectProducer) {
         new Association<>(factory, defaultObjectProducer)
     }
 
     def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, Map<String, ? extends Object> overrides, List<String> traits = null) {
-        hasOne(FactoryManager.instance.getFactoryInstance(factoryClass), overrides, traits)
+        new Association<>(factoryClass, overrides, traits)
     }
 
     def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory, Map<String, ? extends Object> overrides, List<String> traits = null) {
         new Association<>(factory, overrides, traits)
+    }
+
+    def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, List<String> traits) {
+        hasOne(factoryClass, [:], traits)
     }
 
     def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory, List<String> traits) {
@@ -70,7 +73,7 @@ trait FactoryAttributes {
     }
 
     def <T> ManyAssociation<T> hasMany(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, int amount = 0, Map<String, ? extends Object> overrides = null, List<String> traits = null) {
-        hasMany(FactoryManager.instance.getFactoryInstance(factoryClass), amount, overrides, traits)
+        new ManyAssociation<>(factoryClass, amount, overrides, traits)
     }
 
     def <T> ManyAssociation<T> hasMany(BaseFactory<T, ? extends Faker> factory, int amount = 0, Map<String, ? extends Object> overrides = null, List<String> traits = null) {
@@ -88,7 +91,7 @@ trait FactoryAttributes {
     }
 
     def <T> ManyAssociation<T> hasMany(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, List<Object> defaultOverrides, List<String> traits = null) {
-        hasMany(FactoryManager.instance.getFactoryInstance(factoryClass), defaultOverrides, traits)
+        new ManyAssociation<>(factoryClass, defaultOverrides, traits)
     }
 
     def <T> ManyAssociation<T> hasMany(BaseFactory<T, ? extends Faker> factory, List<Object> defaultOverrides, List<String> traits = null) {

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryAttributes.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryAttributes.groovy
@@ -39,12 +39,12 @@ trait FactoryAttributes {
         new Association<>(factory)
     }
 
-    def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, T defaultObject) {
-        hasOne(FactoryManager.instance.getFactoryInstance(factoryClass), defaultObject)
+    def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, Closure<T> defaultObjectProducer) {
+        hasOne(FactoryManager.instance.getFactoryInstance(factoryClass), defaultObjectProducer)
     }
 
-    def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory, T defaultObject) {
-        new Association<>(factory, defaultObject)
+    def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory,  Closure<T> defaultObjectProducer) {
+        new Association<>(factory, defaultObjectProducer)
     }
 
     def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass, Map<String, ? extends Object> overrides, List<String> traits = null) {

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryDSL.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryDSL.groovy
@@ -68,7 +68,7 @@ trait FactoryDSL {
         if (defaultOverrides instanceof Closure) {
             association.defaultOverridesProducer = defaultOverrides
         } else {
-            association.defaultOverridesProducer = { defaultOverrides as Map<String, Object> }
+            association.defaultOverridesProducer = defaultOverrides ? { defaultOverrides as Map<String, Object> } : null
         }
         association.traits = args['traits'] as List<String>
         association.afterBuild = (args['afterBuild'] ?: false) as boolean
@@ -80,9 +80,10 @@ trait FactoryDSL {
         if (generalOverrides instanceof Closure) {
             association.generalOverridesProvider = generalOverrides
         } else {
-            association.generalOverridesProvider = { generalOverrides as Map<String, Object> }
+            association.generalOverridesProvider = generalOverrides ? { generalOverrides as Map<String, Object> } : null
         }
         association.traits = args['traits'] as List<String>
         association.afterBuild = (args['afterBuild'] ?: false) as boolean
+        association.amount = (args['amount'] ?: 0) as int
     }
 }

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryDSL.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryDSL.groovy
@@ -5,7 +5,6 @@ import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import nl.topicus.overheid.javafactorybot.BaseFactory
 import nl.topicus.overheid.javafactorybot.Evaluator
-import nl.topicus.overheid.javafactorybot.FactoryPhase
 import nl.topicus.overheid.javafactorybot.definition.Association
 import nl.topicus.overheid.javafactorybot.definition.ManyAssociation
 import nl.topicus.overheid.javafactorybot.definition.ValueAttribute
@@ -72,7 +71,7 @@ trait FactoryDSL {
             association.defaultOverridesProducer = { defaultOverrides as Map<String, Object> }
         }
         association.traits = args['traits'] as List<String>
-        association.activePhase = (args['phase'] ?: FactoryPhase.INIT) as FactoryPhase
+        association.afterBuild = (args['afterBuild'] ?: false) as boolean
     }
 
     private def parseHasManyArgs(ManyAssociation association, Map<String, ? extends Object> args) {
@@ -84,6 +83,6 @@ trait FactoryDSL {
             association.generalOverridesProvider = { generalOverrides as Map<String, Object> }
         }
         association.traits = args['traits'] as List<String>
-        association.activePhase = (args['phase'] ?: FactoryPhase.INIT) as FactoryPhase
+        association.afterBuild = (args['afterBuild'] ?: false) as boolean
     }
 }

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryDSL.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryDSL.groovy
@@ -29,56 +29,41 @@ trait FactoryDSL {
         new Association<>(factory)
     }
 
-//    def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass,
-//                                  Closure<T> defaultObjectProducer) {
-//        new Association<>(factoryClass, defaultObjectProducer)
-//    }
-//
-//    def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory,
-//                                  Closure<T> defaultObjectProducer) {
-//        new Association<>(factory, defaultObjectProducer)
-//    }
-
-//
-//    def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass,
-//                                  Map<String, ? extends Object> overrides,
-//                                  List<String> traits = null) {
-//        new Association<>(factoryClass, overrides, traits)
-//    }
-//
-//    def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory,
-//                                  Map<String, ? extends Object> overrides,
-//                                  List<String> traits = null) {
-//        new Association<>(factory, overrides, traits)
-//    }
-//
-//    def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass,
-//                                  List<String> traits) {
-//        hasOne(factoryClass, [:], traits)
-//    }
-//
-//    def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory,
-//                                  List<String> traits) {
-//        hasOne(factory, [:], traits)
-//    }
-
-    // Special version for groovy syntax
-    def <T> Association<T> hasOne(Map<String, ? extends Object> args,
-                                  Class<? extends BaseFactory<T, ? extends Faker>> factoryClass) {
+    def <T> Association<T> hasOne(Map<String, ? extends Object> args, Class<? extends BaseFactory<T, ? extends Faker>> factoryClass) {
         Association<T> association = new Association(factoryClass)
-        parseArgs(association, args)
+        parseHasOneArgs(association, args)
+        association
+    }
+
+    def <T> Association<T> hasOne(Map<String, ? extends Object> args, BaseFactory<T, ? extends Faker> factory) {
+        Association<T> association = new Association(factory)
+        parseHasOneArgs(association, args)
+        association
+    }
+
+    def <T> ManyAssociation<T> hasMany(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass) {
+        new ManyAssociation(factoryClass)
+    }
+
+    def <T> ManyAssociation<T> hasMany(BaseFactory<T, ? extends Faker> factory) {
+        new ManyAssociation(factory)
+    }
+
+    // Special version for groovy syntax
+    def <T> ManyAssociation<T> hasMany(Map<String, ? extends Object> args, Class<? extends BaseFactory<T, ? extends Faker>> factoryClass) {
+        def association = new ManyAssociation(factoryClass)
+        parseHasManyArgs(association, args)
         association
     }
 
     // Special version for groovy syntax
-    def <T> Association<T> hasOne(Map<String, ? extends Object> args,
-                                  BaseFactory<T, ? extends Faker> factory) {
-        Association<T> association = new Association(factory)
-        parseArgs(association, args)
+    def <T> ManyAssociation<T> hasMany(Map<String, ? extends Object> args, BaseFactory<T, ? extends Faker> factory) {
+        def association = new ManyAssociation(factory)
+        parseHasManyArgs(association, args)
         association
     }
 
-    def parseArgs(Association association, Map<String, ? extends Object> args) {
+    private def parseHasOneArgs(Association association, Map<String, ? extends Object> args) {
         association.defaultObjectProducer = args['default'] as Closure
         def defaultOverrides = args['overrides']
         if (defaultOverrides instanceof Closure) {
@@ -88,48 +73,17 @@ trait FactoryDSL {
         }
         association.traits = args['traits'] as List<String>
         association.activePhase = (args['phase'] ?: FactoryPhase.INIT) as FactoryPhase
-        association.inverse = args['inverse'] as String
     }
 
-    def <T> ManyAssociation<T> hasMany(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass,
-                                       int amount = 0,
-                                       Map<String, ? extends Object> overrides = null,
-                                       List<String> traits = null) {
-        new ManyAssociation<>(factoryClass, amount, overrides, traits)
-    }
-
-    def <T> ManyAssociation<T> hasMany(BaseFactory<T, ? extends Faker> factory,
-                                       int amount = 0,
-                                       Map<String, ? extends Object> overrides = null,
-                                       List<String> traits = null) {
-        new ManyAssociation<>(factory, amount, overrides, traits)
-    }
-
-    // Special version for groovy syntax
-    def <T> ManyAssociation<T> hasMany(Map<String, ? extends Object> overrides,
-                                       Class<? extends BaseFactory<T, ? extends Faker>> factoryClass,
-                                       int amount = 0,
-                                       List<String> traits = null) {
-        hasMany(factoryClass, amount, overrides, traits)
-    }
-
-    // Special version for groovy syntax
-    def <T> ManyAssociation<T> hasMany(Map<String, ? extends Object> overrides,
-                                       BaseFactory<T, ? extends Faker> factory,
-                                       int amount = 0,
-                                       List<String> traits = null) {
-        hasMany(factory, amount, overrides, traits)
-    }
-
-    def <T> ManyAssociation<T> hasMany(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass,
-                                       List<Object> defaultOverrides,
-                                       List<String> traits = null) {
-        new ManyAssociation<>(factoryClass, defaultOverrides, traits)
-    }
-
-    def <T> ManyAssociation<T> hasMany(BaseFactory<T, ? extends Faker> factory,
-                                       List<Object> defaultOverrides,
-                                       List<String> traits = null) {
-        new ManyAssociation<>(factory, defaultOverrides, traits)
+    private def parseHasManyArgs(ManyAssociation association, Map<String, ? extends Object> args) {
+        association.overrides = args['overrides'] as List
+        def generalOverrides = args['generalOverrides']
+        if (generalOverrides instanceof Closure) {
+            association.generalOverridesProvider = generalOverrides
+        } else {
+            association.generalOverridesProvider = { generalOverrides as Map<String, Object> }
+        }
+        association.traits = args['traits'] as List<String>
+        association.activePhase = (args['phase'] ?: FactoryPhase.INIT) as FactoryPhase
     }
 }

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryDSL.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryDSL.groovy
@@ -9,9 +9,12 @@ import nl.topicus.overheid.javafactorybot.definition.Association
 import nl.topicus.overheid.javafactorybot.definition.ManyAssociation
 import nl.topicus.overheid.javafactorybot.definition.ValueAttribute
 
+/**
+ * Trait containing methods which aid in defining a factory.
+ */
 trait FactoryDSL {
     /**
-     * Creates a new attribute which either uses the user specified override or the result of the closure.
+     * Defines an attribute which either uses the user specified override or the result of the closure.
      *
      * @param defaultValueGenerator The closure which generates a value when no override is given.
      * @return An attribute which resolves to the override or the result of the closure.
@@ -20,49 +23,141 @@ trait FactoryDSL {
         new ValueAttribute(defaultValueGenerator)
     }
 
+    /**
+     * Defines a relationship with a single object.
+     *
+     * @param factoryClass The type of the factory which should be used to generate the related object.
+     * @return An association capable of generating the related object.
+     */
     def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass) {
         new Association<>(factoryClass)
     }
 
+    /**
+     * Defines a relationship with a single object.
+     *
+     * @param factory The factory which should be used to generate the related object.
+     * @return An association capable of generating the related object.
+     */
     def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory) {
         new Association<>(factory)
     }
 
-    def <T> Association<T> hasOne(Map<String, ? extends Object> args, Class<? extends BaseFactory<T, ? extends Faker>> factoryClass) {
+    /**
+     * Defines a relationship with a single object.
+     *
+     * @param options A map containing options for the relationship. Possible options:
+     * <ul>
+     *     <li>default : {@link Closure} - A closure which yields the default object to be used.</li>
+     *     <li>overrides : {@link Map}|{@link Closure} - A map of default overrides, or a closure yielding the default overrides.
+     *     Combined with the user specified overrides, they form the overrides given to the factory. If this relationship is evaluated after the main
+     *     object, the closure is called with the created owner.</li>
+     *     <li>traits : {@link List} - A list of names of traits to apply by default</li>
+     *     <li>afterBuild : {@link Boolean} - Determines if this relationship is evaluated before the object is constructed, or after
+     *     it is created. Defaults to false.</li>
+     * </ul>
+     * @param factoryClass The type of the factory which should be used to generate the related object.
+     * @return An association capable of generating the related object.
+     */
+    def <T> Association<T> hasOne(Map<String, ? extends Object> options, Class<? extends BaseFactory<T, ? extends Faker>> factoryClass) {
         Association<T> association = new Association(factoryClass)
-        parseHasOneArgs(association, args)
+        parseHasOneOptions(association, options)
         association
     }
 
-    def <T> Association<T> hasOne(Map<String, ? extends Object> args, BaseFactory<T, ? extends Faker> factory) {
+    /**
+     * Defines a relationship with a single object.
+     *
+     * @param options A map containing options for the relationship. Possible options:
+     * <ul>
+     *     <li>default : {@link Closure} - A closure which yields the default object to be used.</li>
+     *     <li>overrides : {@link Map}|{@link Closure} - A map of default overrides, or a closure yielding the default overrides.
+     *     Combined with the user specified overrides, they form the overrides given to the factory. If this relationship is evaluated after the main
+     *     object, the closure is called with the created owner.</li>
+     *     <li>traits : {@link List} - A list of names of traits to apply by default</li>
+     *     <li>afterBuild : {@link Boolean} - Determines if this relationship is evaluated before the object is constructed, or after
+     *     it is created. Defaults to false.</li>
+     * </ul>
+     * @param factory The factory which should be used to generate the related object.
+     * @return An association capable of generating the related object.
+     */
+    def <T> Association<T> hasOne(Map<String, ? extends Object> options, BaseFactory<T, ? extends Faker> factory) {
         Association<T> association = new Association(factory)
-        parseHasOneArgs(association, args)
+        parseHasOneOptions(association, options)
         association
     }
 
+    /**
+     * Defines a relationship with multiple objects.
+     *
+     * @param factoryClass The type of the factory which should be used to generate the related objects.
+     * @return An association capable of generating the related objects.
+     */
     def <T> ManyAssociation<T> hasMany(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass) {
         new ManyAssociation(factoryClass)
     }
 
+    /**
+     * Defines a relationship with multiple objects.
+     *
+     * @param factory The factory which should be used to generate the related objects.
+     * @return An association capable of generating the related objects.
+     */
     def <T> ManyAssociation<T> hasMany(BaseFactory<T, ? extends Faker> factory) {
         new ManyAssociation(factory)
     }
 
-    // Special version for groovy syntax
-    def <T> ManyAssociation<T> hasMany(Map<String, ? extends Object> args, Class<? extends BaseFactory<T, ? extends Faker>> factoryClass) {
+    /**
+     * Defines a relationship with multiple objects.
+     *
+     * @param options A map containing options for the relationship. Possible options:
+     * <ul>
+     *     <li>overrides : {@link List} - A list containing overrides (maps) or the related objects which should be used by the factory.</li>
+     *     <li>generalOverrides : {@link Map}|{@link Closure} - A map of default overrides, or a closure yielding the default overrides.
+     *     Combined with the user specified overrides, they form the overrides given to the factory. If this relationship is evaluated after the main
+     *     object, the closure is called with the created owner.</li>
+     *     <li>traits : {@link List} - A list of names of traits to apply by default</li>
+     *     <li>afterBuild : {@link Boolean} - Determines if this relationship is evaluated before the object is constructed, or after
+     *     it is created. Defaults to false.</li>
+     *     <li>amount : {@link Integer} - The number of related objects to generate, if no other amount or list of overrides is specified.</li>
+     *     <li>transform : {@link Closure} - A closure which gets the generated list of related objects and returns a transformed collection.
+     *     This can be useful if the final collection should not be a list but any other type, like a set.</li>
+     * </ul>
+     * @param factoryClass The type of the factory which should be used to generate the related objects.
+     * @return An association capable of generating the related objects.
+     */
+    def <T> ManyAssociation<T> hasMany(Map<String, ? extends Object> options, Class<? extends BaseFactory<T, ? extends Faker>> factoryClass) {
         def association = new ManyAssociation(factoryClass)
-        parseHasManyArgs(association, args)
+        parseHasManyOptions(association, options)
         association
     }
 
-    // Special version for groovy syntax
-    def <T> ManyAssociation<T> hasMany(Map<String, ? extends Object> args, BaseFactory<T, ? extends Faker> factory) {
+    /**
+     * Defines a relationship with multiple objects.
+     *
+     * @param options A map containing options for the relationship. Possible options:
+     * <ul>
+     *     <li>overrides : {@link List} - A list containing overrides (maps) or the related objects which should be used by the factory.</li>
+     *     <li>generalOverrides : {@link Map}|{@link Closure} - A map of default overrides, or a closure yielding the default overrides.
+     *     Combined with the user specified overrides, they form the overrides given to the factory. If this relationship is evaluated after the main
+     *     object, the closure is called with the created owner.</li>
+     *     <li>traits : {@link List} - A list of names of traits to apply by default</li>
+     *     <li>afterBuild : {@link Boolean} - Determines if this relationship is evaluated before the object is constructed, or after
+     *     it is created. Defaults to false.</li>
+     *     <li>amount : {@link Integer} - The number of related objects to generate, if no other amount or list of overrides is specified.</li>
+     *     <li>transform : {@link Closure} - A closure which gets the generated list of related objects and returns a transformed collection.
+     *     This can be useful if the final collection should not be a list but any other type, like a set.</li>
+     * </ul>
+     * @param factory The factory which should be used to generate the related objects.
+     * @return An association capable of generating the related objects.
+     */
+    def <T> ManyAssociation<T> hasMany(Map<String, ? extends Object> options, BaseFactory<T, ? extends Faker> factory) {
         def association = new ManyAssociation(factory)
-        parseHasManyArgs(association, args)
+        parseHasManyOptions(association, options)
         association
     }
 
-    private def parseHasOneArgs(Association association, Map<String, ? extends Object> args) {
+    private def parseHasOneOptions(Association association, Map<String, ? extends Object> args) {
         association.defaultObjectProducer = args['default'] as Closure
         def defaultOverrides = args['overrides']
         if (defaultOverrides instanceof Closure) {
@@ -74,7 +169,7 @@ trait FactoryDSL {
         association.afterBuild = (args['afterBuild'] ?: false) as boolean
     }
 
-    private def parseHasManyArgs(ManyAssociation association, Map<String, ? extends Object> args) {
+    private def parseHasManyOptions(ManyAssociation association, Map<String, ? extends Object> args) {
         association.overrides = args['overrides'] as List
         def generalOverrides = args['generalOverrides']
         if (generalOverrides instanceof Closure) {

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryDSL.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryDSL.groovy
@@ -85,5 +85,6 @@ trait FactoryDSL {
         association.traits = args['traits'] as List<String>
         association.afterBuild = (args['afterBuild'] ?: false) as boolean
         association.amount = (args['amount'] ?: 0) as int
+        association.transform = args['transform'] as Closure
     }
 }

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryDSL.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryDSL.groovy
@@ -1,0 +1,135 @@
+package nl.topicus.overheid.javafactorybot.factory
+
+import com.github.javafaker.Faker
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.SimpleType
+import nl.topicus.overheid.javafactorybot.BaseFactory
+import nl.topicus.overheid.javafactorybot.Evaluator
+import nl.topicus.overheid.javafactorybot.FactoryPhase
+import nl.topicus.overheid.javafactorybot.definition.Association
+import nl.topicus.overheid.javafactorybot.definition.ManyAssociation
+import nl.topicus.overheid.javafactorybot.definition.ValueAttribute
+
+trait FactoryDSL {
+    /**
+     * Creates a new attribute which either uses the user specified override or the result of the closure.
+     *
+     * @param defaultValueGenerator The closure which generates a value when no override is given.
+     * @return An attribute which resolves to the override or the result of the closure.
+     */
+    ValueAttribute value(@DelegatesTo(Evaluator) @ClosureParams(value = SimpleType, options = "Evaluator") Closure defaultValueGenerator) {
+        new ValueAttribute(defaultValueGenerator)
+    }
+
+    def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass) {
+        new Association<>(factoryClass)
+    }
+
+    def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory) {
+        new Association<>(factory)
+    }
+
+//    def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass,
+//                                  Closure<T> defaultObjectProducer) {
+//        new Association<>(factoryClass, defaultObjectProducer)
+//    }
+//
+//    def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory,
+//                                  Closure<T> defaultObjectProducer) {
+//        new Association<>(factory, defaultObjectProducer)
+//    }
+
+//
+//    def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass,
+//                                  Map<String, ? extends Object> overrides,
+//                                  List<String> traits = null) {
+//        new Association<>(factoryClass, overrides, traits)
+//    }
+//
+//    def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory,
+//                                  Map<String, ? extends Object> overrides,
+//                                  List<String> traits = null) {
+//        new Association<>(factory, overrides, traits)
+//    }
+//
+//    def <T> Association<T> hasOne(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass,
+//                                  List<String> traits) {
+//        hasOne(factoryClass, [:], traits)
+//    }
+//
+//    def <T> Association<T> hasOne(BaseFactory<T, ? extends Faker> factory,
+//                                  List<String> traits) {
+//        hasOne(factory, [:], traits)
+//    }
+
+    // Special version for groovy syntax
+    def <T> Association<T> hasOne(Map<String, ? extends Object> args,
+                                  Class<? extends BaseFactory<T, ? extends Faker>> factoryClass) {
+        Association<T> association = new Association(factoryClass)
+        parseArgs(association, args)
+        association
+    }
+
+    // Special version for groovy syntax
+    def <T> Association<T> hasOne(Map<String, ? extends Object> args,
+                                  BaseFactory<T, ? extends Faker> factory) {
+        Association<T> association = new Association(factory)
+        parseArgs(association, args)
+        association
+    }
+
+    def parseArgs(Association association, Map<String, ? extends Object> args) {
+        association.defaultObjectProducer = args['default'] as Closure
+        def defaultOverrides = args['overrides']
+        if (defaultOverrides instanceof Closure) {
+            association.defaultOverridesProducer = defaultOverrides
+        } else {
+            association.defaultOverridesProducer = { defaultOverrides as Map<String, Object> }
+        }
+        association.traits = args['traits'] as List<String>
+        association.activePhase = (args['phase'] ?: FactoryPhase.INIT) as FactoryPhase
+        association.inverse = args['inverse'] as String
+    }
+
+    def <T> ManyAssociation<T> hasMany(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass,
+                                       int amount = 0,
+                                       Map<String, ? extends Object> overrides = null,
+                                       List<String> traits = null) {
+        new ManyAssociation<>(factoryClass, amount, overrides, traits)
+    }
+
+    def <T> ManyAssociation<T> hasMany(BaseFactory<T, ? extends Faker> factory,
+                                       int amount = 0,
+                                       Map<String, ? extends Object> overrides = null,
+                                       List<String> traits = null) {
+        new ManyAssociation<>(factory, amount, overrides, traits)
+    }
+
+    // Special version for groovy syntax
+    def <T> ManyAssociation<T> hasMany(Map<String, ? extends Object> overrides,
+                                       Class<? extends BaseFactory<T, ? extends Faker>> factoryClass,
+                                       int amount = 0,
+                                       List<String> traits = null) {
+        hasMany(factoryClass, amount, overrides, traits)
+    }
+
+    // Special version for groovy syntax
+    def <T> ManyAssociation<T> hasMany(Map<String, ? extends Object> overrides,
+                                       BaseFactory<T, ? extends Faker> factory,
+                                       int amount = 0,
+                                       List<String> traits = null) {
+        hasMany(factory, amount, overrides, traits)
+    }
+
+    def <T> ManyAssociation<T> hasMany(Class<? extends BaseFactory<T, ? extends Faker>> factoryClass,
+                                       List<Object> defaultOverrides,
+                                       List<String> traits = null) {
+        new ManyAssociation<>(factoryClass, defaultOverrides, traits)
+    }
+
+    def <T> ManyAssociation<T> hasMany(BaseFactory<T, ? extends Faker> factory,
+                                       List<Object> defaultOverrides,
+                                       List<String> traits = null) {
+        new ManyAssociation<>(factory, defaultOverrides, traits)
+    }
+}

--- a/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryHooks.groovy
+++ b/src/main/groovy/nl/topicus/overheid/javafactorybot/factory/FactoryHooks.groovy
@@ -17,16 +17,4 @@ trait FactoryHooks<M> {
      */
     void onAfterBuild(M model) {
     }
-
-    /**
-     * Callback which is called after the model is created (built and saved) using the evaluated attributes,
-     * but before it is returned as result of the create() method. This allows to tweak the model,
-     * for example to fix relationships.
-     *
-     * This callback is only used when models are created using {@link nl.topicus.overheid.javafactorybot.BaseFactory#create}
-     *
-     * @param model The model after it was created using the evaluated attributes. Can be null
-     */
-    void onAfterCreate(M model) {
-    }
 }

--- a/src/test/groovy/nl/topicus/overheid/javafactorybot/test/factory/ArticleFactory.groovy
+++ b/src/test/groovy/nl/topicus/overheid/javafactorybot/test/factory/ArticleFactory.groovy
@@ -8,34 +8,22 @@ import nl.topicus.overheid.javafactorybot.test.model.Article
 import java.util.concurrent.TimeUnit
 
 class ArticleFactory extends Factory<Article> {
-    @Override
-    Map<String, Attribute> getAttributes() {
-        [
-                title       : value { faker.lorem().sentence() },
-                content     : value { faker.lorem().paragraph() },
-                creationDate: value { faker.date().past(20, TimeUnit.DAYS) },
-                summary     : value { null },
-                author      : hasOne(UserFactory),
-                comments    : hasMany(CommentFactory)
-        ]
-    }
+    Map<String, Attribute> attributes = [
+            title       : value { faker.lorem().sentence() },
+            content     : value { faker.lorem().paragraph() },
+            creationDate: value { faker.date().past(20, TimeUnit.DAYS) },
+            summary     : value { null },
+            author      : hasOne(UserFactory),
+            comments    : hasMany(CommentFactory, afterBuild: true, defaultOverrides: { Article it -> [article: it] })
+    ]
 
-    @Override
-    void onAfterBuild(Article article) {
-        article?.comments.each { it.article = article }
-    }
+    Map<String, Trait> traits = [
+            withComments: new WithCommentsTrait()
+    ]
 
-    @Override
-    Map<String, Trait> getTraits() {
-        [
-                withComments: new Trait() {
-                    @Override
-                    Map<String, Attribute> getAttributes() {
-                        [
-                                comments: hasMany(CommentFactory, 3, article: null as Article)
-                        ]
-                    }
-                }
+    class WithCommentsTrait extends Trait<Article> {
+        Map<String, Attribute> attributes = [
+                comments: hasMany(CommentFactory, amount: 3)
         ]
     }
 }

--- a/src/test/groovy/nl/topicus/overheid/javafactorybot/test/factory/ArticleFactory.groovy
+++ b/src/test/groovy/nl/topicus/overheid/javafactorybot/test/factory/ArticleFactory.groovy
@@ -11,10 +11,10 @@ class ArticleFactory extends Factory<Article> {
     @Override
     Map<String, Attribute> getAttributes() {
         [
-                title       : attribute { faker.lorem().sentence() },
-                content     : attribute { faker.lorem().paragraph() },
-                creationDate: attribute { faker.date().past(20, TimeUnit.DAYS) },
-                summary     : attribute { null },
+                title       : value { faker.lorem().sentence() },
+                content     : value { faker.lorem().paragraph() },
+                creationDate: value { faker.date().past(20, TimeUnit.DAYS) },
+                summary     : value { null },
                 author      : hasOne(UserFactory),
                 comments    : hasMany(CommentFactory)
         ]

--- a/src/test/groovy/nl/topicus/overheid/javafactorybot/test/factory/CommentFactory.groovy
+++ b/src/test/groovy/nl/topicus/overheid/javafactorybot/test/factory/CommentFactory.groovy
@@ -12,8 +12,8 @@ class CommentFactory extends Factory<Comment> {
         [
                 article     : hasOne(ArticleFactory),
                 author      : hasOne(UserFactory),
-                content     : attribute { faker.lorem().paragraph() },
-                creationDate: attribute { faker.date().past(20, TimeUnit.DAYS) }
+                content     : value { faker.lorem().paragraph() },
+                creationDate: value { faker.date().past(20, TimeUnit.DAYS) }
         ]
     }
 }

--- a/src/test/groovy/nl/topicus/overheid/javafactorybot/test/factory/CommentFactory.groovy
+++ b/src/test/groovy/nl/topicus/overheid/javafactorybot/test/factory/CommentFactory.groovy
@@ -7,13 +7,10 @@ import nl.topicus.overheid.javafactorybot.test.model.Comment
 import java.util.concurrent.TimeUnit
 
 class CommentFactory extends Factory<Comment> {
-    @Override
-    Map<String, Attribute> getAttributes() {
-        [
-                article     : hasOne(ArticleFactory),
-                author      : hasOne(UserFactory),
-                content     : value { faker.lorem().paragraph() },
-                creationDate: value { faker.date().past(20, TimeUnit.DAYS) }
-        ]
-    }
+    Map<String, Attribute> attributes = [
+            article     : hasOne(ArticleFactory),
+            author      : hasOne(UserFactory),
+            content     : value { faker.lorem().paragraph() },
+            creationDate: value { faker.date().past(20, TimeUnit.DAYS) }
+    ]
 }

--- a/src/test/groovy/nl/topicus/overheid/javafactorybot/test/factory/UserFactory.groovy
+++ b/src/test/groovy/nl/topicus/overheid/javafactorybot/test/factory/UserFactory.groovy
@@ -5,13 +5,10 @@ import nl.topicus.overheid.javafactorybot.definition.Attribute
 import nl.topicus.overheid.javafactorybot.test.model.User
 
 class UserFactory extends Factory<User> {
-    @Override
-    Map<String, Attribute> getAttributes() {
-        [
-                username : value { faker.name().username() },
-                firstName: value { faker.name().firstName() },
-                lastName : value { faker.name().lastName() },
-                email    : value { "${get("firstName")}.${get("lastName")}@example.com" }
-        ]
-    }
+    Map<String, Attribute> attributes = [
+            username : value { faker.name().username() },
+            firstName: value { faker.name().firstName() },
+            lastName : value { faker.name().lastName() },
+            email    : value { "${get("firstName")}.${get("lastName")}@example.com" }
+    ]
 }

--- a/src/test/groovy/nl/topicus/overheid/javafactorybot/test/factory/UserFactory.groovy
+++ b/src/test/groovy/nl/topicus/overheid/javafactorybot/test/factory/UserFactory.groovy
@@ -8,10 +8,10 @@ class UserFactory extends Factory<User> {
     @Override
     Map<String, Attribute> getAttributes() {
         [
-                username : attribute { faker.name().username() },
-                firstName: attribute { faker.name().firstName() },
-                lastName : attribute { faker.name().lastName() },
-                email    : attribute { "${get("firstName")}.${get("lastName")}@example.com" }
+                username : value { faker.name().username() },
+                firstName: value { faker.name().firstName() },
+                lastName : value { faker.name().lastName() },
+                email    : value { "${get("firstName")}.${get("lastName")}@example.com" }
         ]
     }
 }


### PR DESCRIPTION
# Changelog
- Improved structure of factory and build process (see PROCESS.md)
- Slightly changed DSL for relations (which means less methods to maintain en better readability)
- Fixes for circular dependencies between factories (for example when you have a car with wheels, and want to be able to build cars with wheels, while wheels always require to be part of a car)
- New features allow to create relations after the owner object has been created. This can be done by passing `afterBuild: true` to definition of the relation (either `hasOne` or `hasMany`). The `overrides` (in case of `hasOne`) or `generalOverrides` (in case of `hasMany`) can now be a closure which recieves the created owner object as argument. This is especially helpfull in case of composite relations, where the smaller object requires to know the composed object. Example:

```groovy
class UserFactory {
    Map<String, Attribute> attributes = [
        address: hasOne(AddresFactory, afterBuild: true, overrides: {User user -> [user: user]})
    ]
}
```

When building a user, the User object is build first. After this, one Addres is created where the user is passed as override. When the Addres is created, the result is set on the `address` property of the user, and the User is returned as result of `UserFactory.build()`